### PR TITLE
feat: add YVM Formula

### DIFF
--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -25,9 +25,9 @@ class Yvm < Formula
     end
     chmod 0755, 'yvm.sh'
     makedirs '/usr/local/var/yvm/versions'
-    `ln -s /usr/local/var/yvm/versions ./versions`
-    `echo '{ "version": "#{version}" }' > .version`
-    prefix.install ['.version', 'node_modules', 'yvm.sh', 'yvm.fish', 'yvm.js', 'yvm-exec.js']
+    ln_s '/usr/local/var/yvm/versions', './versions'
+    File.write('.version', "{ \"version\": \"#{version}\" }")
+    prefix.install ['.version', 'versions', 'node_modules', 'yvm.sh', 'yvm.fish', 'yvm.js', 'yvm-exec.js']
   end
 
   def caveats

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -27,6 +27,7 @@ class Yvm < Formula
   end
 
   def caveats
+    home = `eval echo "~"`
     s = <<~EOS
       To load yvm in the shell add to your ~/.bashrc or ~/.zsh
       export YVM_DIR=#{home}/.yvm

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -26,10 +26,8 @@ class Yvm < Formula
     chmod 0755, 'yvm.sh'
     makedirs '/usr/local/var/yvm/versions'
     `ln -s /usr/local/var/yvm/versions ./versions`
-    open('.version', 'w') do |f|
-        f << "{ \"version\": \"#{version}\" }"
-    end
-    prefix.install Dir['*']
+    `echo '{ "version": "#{version}" }' > .version`
+    prefix.install ['.version', 'node_modules', 'yvm.sh', 'yvm.fish', 'yvm.js', 'yvm-exec.js']
   end
 
   def caveats

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -14,7 +14,7 @@ class Yvm < Formula
   conflicts_with 'yarn', because: 'yvm installs and manages yarn'
 
   def install
-    update_self_disabled = 'echo "Yvm update-self disabled. Installed via homebrew."'
+    update_self_disabled = 'echo "YVM update-self disabled. Use `brew upgrade yvm`."'
     inreplace 'yvm.sh' do |s|
         s.gsub! 'YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}', "YVM_DIR='#{prefix}'"
         s.gsub! 'curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash', update_self_disabled
@@ -24,6 +24,11 @@ class Yvm < Formula
         s.gsub! 'env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash', update_self_disabled
     end
     chmod 0755, 'yvm.sh'
+    makedirs '/usr/local/var/yvm/versions'
+    `ln -s /usr/local/var/yvm/versions ./versions`
+    open('.version', 'w') do |f|
+        f << "{ \"version\": \"#{version}\" }"
+    end
     prefix.install Dir['*']
   end
 
@@ -33,9 +38,13 @@ class Yvm < Formula
       export YVM_DIR='#{prefix}'
       [ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
 
-      And for you fishers to your ~/.config/fish/config.fish
+      And for fishers, add to your ~/.config/fish/config.fish
       set -x YVM_DIR '#{prefix}'
       source . $YVM_DIR/yvm.fish
+
+      If you have previously installed YVM, link the versions folder
+      to allow all brewed YVM access to the managed yarn distributions
+      $ ln -sF ~/.yvm/versions /usr/local/var/yvm
     EOS
     emptor
   end

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -1,43 +1,43 @@
 # Yarn Version Manager
 class Yvm < Formula
-  desc 'Manage multiple versions of Yarn'
-  homepage 'https://yvm.js.org'
+  desc "Manage multiple versions of Yarn"
+  homepage "https://yvm.js.org"
   # Should only be updated if a newer version is listed as a stable release
-  url 'https://github.com/tophat/yvm/releases/download/v2.4.1/yvm.zip'
-  sha256 '82e0e3ee1e66ad389641fef9d9c3a164124cd63e89323a77e03a30fa9d5ecfdf'
+  url "https://github.com/tophat/yvm/releases/download/v2.4.1/yvm.zip"
+  sha256 "82e0e3ee1e66ad389641fef9d9c3a164124cd63e89323a77e03a30fa9d5ecfdf"
 
   bottle :unneeded
 
-  depends_on 'node' => %i[recommended optional] # Ignore if node already managed
+  depends_on "node" => [:recommended, :optional] # Ignore if node already managed
 
-  conflicts_with 'hadoop', because: 'both install `yarn` binaries'
-  conflicts_with 'yarn', because: 'yvm installs and manages yarn'
+  conflicts_with "hadoop", :because => "both install `yarn` binaries"
+  conflicts_with "yarn", :because => "yvm installs and manages yarn"
 
   def install
-    update_self_disabled = 'echo "YVM update-self disabled. Use `brew upgrade yvm`."'
-    inreplace 'yvm.sh' do |s|
-        s.gsub! 'YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}', "YVM_DIR='#{prefix}'"
-        s.gsub! 'curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash', update_self_disabled
+    update_self_disabled = "echo 'YVM update-self disabled. Use `brew upgrade yvm`.'"
+    inreplace "yvm.sh" do |s|
+      s.gsub! 'YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}', "YVM_DIR='#{prefix}'"
+      s.gsub! "curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash", update_self_disabled
     end
-    inreplace 'yvm.fish' do |s|
-        s.gsub! 'set -q YVM_DIR; or set -U YVM_DIR "$HOME/.yvm"', "set -U YVM_DIR '#{prefix}'"
-        s.gsub! 'env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash', update_self_disabled
+    inreplace "yvm.fish" do |s|
+      s.gsub! 'set -q YVM_DIR; or set -U YVM_DIR "$HOME/.yvm"', "set -U YVM_DIR '#{prefix}'"
+      s.gsub! "env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash", update_self_disabled
     end
-    chmod 0755, 'yvm.sh'
-    makedirs '/usr/local/var/yvm/versions'
-    ln_s '/usr/local/var/yvm/versions', './versions'
-    File.write('.version', "{ \"version\": \"#{version}\" }")
-    prefix.install ['.version', 'versions', 'node_modules', 'yvm.sh', 'yvm.fish', 'yvm.js', 'yvm-exec.js']
+    chmod 0755, "yvm.sh"
+    makedirs "/usr/local/var/yvm/versions"
+    ln_s "/usr/local/var/yvm/versions", "./versions"
+    File.write(".version", "{ \"version\": \"#{version}\" }")
+    prefix.install [".version", "versions", "node_modules", "yvm.sh", "yvm.fish", "yvm.js", "yvm-exec.js"]
   end
 
   def caveats
     emptor = <<~EOS
       To load yvm in the shell add to your ~/.bashrc or ~/.zsh
-      export YVM_DIR='#{prefix}'
+      export YVM_DIR="#{prefix}"
       [ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
 
       And for fishers, add to your ~/.config/fish/config.fish
-      set -x YVM_DIR '#{prefix}'
+      set -x YVM_DIR "#{prefix}"
       source . $YVM_DIR/yvm.fish
 
       If you have previously installed YVM, link the versions folder

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -48,7 +48,7 @@ class Yvm < Formula
   end
 
   test do
-    system "#{prefix}/yvm.sh ls"
-    system "#{prefix}/yvm.sh ls-remote"
+    system "#{prefix}/yvm.sh", "ls"
+    system "#{prefix}/yvm.sh", "ls-remote"
   end
 end

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -15,28 +15,29 @@ class Yvm < Formula
 
   def install
     update_self_disabled = 'echo "Yvm update-self disabled. Installed via homebrew."'
-    inreplace 'yvm.sh', 'curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash', update_self_disabled
-    inreplace 'yvm.fish', 'env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash', update_self_disabled
-    chmod 755, 'yvm.sh'
+    inreplace 'yvm.sh' do |s|
+        s.gsub! 'YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}', "YVM_DIR='#{prefix}'"
+        s.gsub! 'curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash', update_self_disabled
+    end
+    inreplace 'yvm.fish' do |s|
+        s.gsub! 'set -q YVM_DIR; or set -U YVM_DIR "$HOME/.yvm"', "set -U YVM_DIR '#{prefix}'"
+        s.gsub! 'env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash', update_self_disabled
+    end
+    chmod 0755, 'yvm.sh'
     prefix.install Dir['*']
   end
 
   def caveats
-    usr_home = `eval echo "~"`.strip
-    yvm_home = usr_home+'/.yvm'
-    system 'mkdir', '-p', yvm_home
-    system 'ln', '-sf', prefix/'yvm.sh', yvm_home+'/yvm.sh'
-    system 'ln', '-sf', prefix/'yvm.fish', yvm_home+'/yvm.fish'
-    s = <<~EOS
+    emptor = <<~EOS
       To load yvm in the shell add to your ~/.bashrc or ~/.zsh
-      export YVM_DIR=#{yvm_home}
+      export YVM_DIR='#{prefix}'
       [ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
 
       And for you fishers to your ~/.config/fish/config.fish
-      set -x YVM_DIR #{yvm_home}
+      set -x YVM_DIR '#{prefix}'
       source . $YVM_DIR/yvm.fish
     EOS
-    s
+    emptor
   end
 
   test do

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -2,34 +2,41 @@
 class Yvm < Formula
   desc 'Manage multiple versions of Yarn'
   homepage 'https://yvm.js.org'
-  # Should only be updated if the new version is listed as a stable release
+  # Should only be updated if a newer version is listed as a stable release
   url 'https://github.com/tophat/yvm/releases/download/v2.4.1/yvm.zip'
   sha256 '82e0e3ee1e66ad389641fef9d9c3a164124cd63e89323a77e03a30fa9d5ecfdf'
 
   bottle :unneeded
 
   depends_on 'node' => %i[recommended optional] # Ignore if node already managed
-  depends_on 'unzip' => %i[build optional] # Ignore if unzip already installed
-  depends_on 'curl' => %i[build optional] # Ignore if curl already installed
 
   conflicts_with 'hadoop', because: 'both install `yarn` binaries'
   conflicts_with 'yarn', because: 'yvm installs and manages yarn'
 
   def install
+    update_self_disabled = 'echo "Yvm update-self disabled. Installed via homebrew."'
+    inreplace 'yvm.sh', 'curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash', update_self_disabled
+    inreplace 'yvm.fish', 'env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash', update_self_disabled
     chmod 755, 'yvm.sh'
-    inreplace ['yvm.sh', 'yvm.fish'], 'curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash', 'echo "Yvm update-self disabled. Installed via homebrew."'
-    cp 'yvm.sh', bin / 'yvm'
     prefix.install Dir['*']
+    usr_home = `eval echo "~"`
+    yvm_home = usr_home+'/.yvm'
+    system 'mkdir', '-p', yvm_home
+    system 'ln', '-sf', prefix/'yvm.sh', yvm_home+'/yvm.sh'
+    system 'ln', '-sf', prefix/'yvm.fish', yvm_home+'/yvm.fish'
   end
 
-  def post_install
-    echo '~~~ Caveats ~~~'
-    echo 'Add this to your ~/.bashrc or ~/.zsh'
-    echo "export YVM_DIR=#{prefix}"
-    echo '[ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh'
-    echo 'And for you fishers to your ~/.config/fish/config.fish'
-    echo "set -x YVM_DIR #{prefix}"
-    echo 'source . $YVM_DIR/yvm.fish'
+  def caveats
+    s = <<~EOS
+      To load yvm in the shell add to your ~/.bashrc or ~/.zsh
+      export YVM_DIR=#{home}/.yvm
+      [ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
+
+      And for you fishers to your ~/.config/fish/config.fish
+      set -x YVM_DIR #{home}/.yvm
+      source . $YVM_DIR/yvm.fish
+    EOS
+    s
   end
 
   test do

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -48,6 +48,7 @@ class Yvm < Formula
   end
 
   test do
-    system 'bash -l -c "yvm --version"'
+    system "#{prefix}/yvm.sh ls"
+    system "#{prefix}/yvm.sh ls-remote"
   end
 end

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -1,24 +1,38 @@
-# yvm formula
+# Yarn Version Manager
 class Yvm < Formula
-  desc 'Yarn Version Manager'
+  desc 'Manage multiple versions of Yarn'
   homepage 'https://yvm.js.org'
   # Should only be updated if the new version is listed as a stable release
-  url 'https://github.com/tophat/yvm/archive/v2.4.1.tar.gz'
+  url 'https://github.com/tophat/yvm/releases/download/v2.4.1/yvm.zip'
+  sha256 '82e0e3ee1e66ad389641fef9d9c3a164124cd63e89323a77e03a30fa9d5ecfdf'
 
   bottle :unneeded
 
-  depends_on 'node' => :recommended
-  depends_on 'unzip' => :build
-  depends_on 'curl' => :build
+  depends_on 'node' => %i[recommended optional] # Ignore if node already managed
+  depends_on 'unzip' => %i[build optional] # Ignore if unzip already installed
+  depends_on 'curl' => %i[build optional] # Ignore if curl already installed
 
   conflicts_with 'hadoop', because: 'both install `yarn` binaries'
   conflicts_with 'yarn', because: 'yvm installs and manages yarn'
 
   def install
-    system 'make', 'install'
+    chmod 755, 'yvm.sh'
+    inreplace ['yvm.sh', 'yvm.fish'], 'curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | YVM_INSTALL_DIR=${YVM_DIR} bash', 'echo "Yvm update-self disabled. Installed via homebrew."'
+    cp 'yvm.sh', bin / 'yvm'
+    prefix.install Dir['*']
+  end
+
+  def post_install
+    echo '~~~ Caveats ~~~'
+    echo 'Add this to your ~/.bashrc or ~/.zsh'
+    echo "export YVM_DIR=#{prefix}"
+    echo '[ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh'
+    echo 'And for you fishers to your ~/.config/fish/config.fish'
+    echo "set -x YVM_DIR #{prefix}"
+    echo 'source . $YVM_DIR/yvm.fish'
   end
 
   test do
-    system bin / 'bash -l -c "yvm --version"'
+    system 'bash -l -c "yvm --version"'
   end
 end

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -19,22 +19,21 @@ class Yvm < Formula
     inreplace 'yvm.fish', 'env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm/master/scripts/install.sh | bash', update_self_disabled
     chmod 755, 'yvm.sh'
     prefix.install Dir['*']
-    usr_home = `eval echo "~"`
+  end
+
+  def caveats
+    usr_home = `eval echo "~"`.strip
     yvm_home = usr_home+'/.yvm'
     system 'mkdir', '-p', yvm_home
     system 'ln', '-sf', prefix/'yvm.sh', yvm_home+'/yvm.sh'
     system 'ln', '-sf', prefix/'yvm.fish', yvm_home+'/yvm.fish'
-  end
-
-  def caveats
-    home = `eval echo "~"`
     s = <<~EOS
       To load yvm in the shell add to your ~/.bashrc or ~/.zsh
-      export YVM_DIR=#{home}/.yvm
+      export YVM_DIR=#{yvm_home}
       [ -r $YVM_DIR/yvm.sh ] && source $YVM_DIR/yvm.sh
 
       And for you fishers to your ~/.config/fish/config.fish
-      set -x YVM_DIR #{home}/.yvm
+      set -x YVM_DIR #{yvm_home}
       source . $YVM_DIR/yvm.fish
     EOS
     s


### PR DESCRIPTION
# Description
tophat/yvm/issues/206

### QA Prep
- Have brew installed and healthy

### QA Steps
- `brew install ./Formula/yvm.rb`
- `/usr/local/opt/yvm/yvm.sh version` should print `2.4.1`
- `/usr/local/opt/yvm/yvm.sh ls` will likely be empty
- Follow the steps in the caveat
  - reload your shell or source the installed yvm
  - `ln -sF ~/.yvm/versions /usr/local/var/yvm` (if you previously had yvm installed)
  - `yvm ls` should show installed yarn versions
  - `yvm update-self` should be disabled

### Sanity
- `brew audit --new-formula Formula/yvm.rb`
- `brew audit --strict --online Formula/yvm.rb`
- `brew test Formula/yvm.rb`

### Notes
- Follow up work needs to be done to support [manuals](https://docs.brew.sh/Formula-Cookbook#manuals)