### PR TITLE
fix(yvm): replace shell config attempt with post install instructions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  NewCops: enable
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -13,11 +13,18 @@ class Yvm < Formula
   conflicts_with "hadoop", because: "both install `yarn` binaries"
   conflicts_with "yarn", because: "yvm installs and manages yarn"
 
-  def install
-    File.write("#{ENV['HOME']}/.bashrc", "")
-    mkdir_p "#{ENV['HOME']}/.config/fish"
-    File.write("#{ENV['HOME']}/.config/fish/config.fish", "")
-    system "node", "yvm.js", "configure-shell", "--yvmDir", "."
+  def write_install_files
+    File.write(".bashrc", "")
+    File.write(".zshrc", "")
+    mkdir_p ".config/fish"
+    File.write(".config/fish/config.fish", "")
+    File.write(".version", "{ \"version\": \"#{version}\" }")
+    system "node", "yvm.js", "configure-shell", "--yvmDir", ".", "--home", "."
+    mv ".bashrc", ".config"
+    mv ".zshrc", ".config"
+  end
+
+  def patch_install_files
     update_self_disabled = "echo 'YVM update-self disabled. Use `brew upgrade yvm`.'"
     inreplace "yvm.sh" do |s|
       s.gsub! 'YVM_DIR=${YVM_DIR-"${HOME}/.yvm"}', "YVM_DIR='#{prefix}'"
@@ -29,22 +36,28 @@ class Yvm < Formula
       s.gsub! "env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm"\
               "/master/scripts/install.js | node", update_self_disabled
     end
-    yarn_versions_dir = "#{ENV['HOME']}/.yvm/versions"
-    mkdir_p yarn_versions_dir
-    ln_sf yarn_versions_dir, "./versions"
-    File.write(".version", "{ \"version\": \"#{version}\" }")
-    prefix.install [".version", "versions", "shim", "yvm.sh", "yvm.fish", "yvm.js"]
+  end
+
+  def install
+    write_install_files
+    patch_install_files
+    prefix.install [".version", ".config", "shim", "yvm.sh", "yvm.fish", "yvm.js"]
   end
 
   def caveats
     <<~POSTINSTALLCONFIG
       Run the following command to configure your shell rc file
       $ node "#{prefix}/yvm.js" configure-shell --yvmDir "#{prefix}"
+      See "#{prefix}/.config" for examples.
+
+      If you have previously installed YVM, link the versions folder
+      to allow all brewed YVM access to the managed yarn distributions
+      $ ln -sF ~/.yvm/versions #{prefix}
     POSTINSTALLCONFIG
   end
 
   test do
-    File.write("#{ENV['HOME']}/.bashrc", "")
+    File.write("#{ENV["HOME"]}/.bashrc", "")
     system "node", "#{prefix}/yvm.js", "configure-shell", "--yvmDir", prefix.to_s
     assert_match prefix.to_s, shell_output("bash -i -c 'echo $YVM_DIR'").strip
     shell_output("bash -i -c 'yvm ls-remote'")

--- a/Formula/yvm.rb
+++ b/Formula/yvm.rb
@@ -14,9 +14,9 @@ class Yvm < Formula
   conflicts_with "yarn", because: "yvm installs and manages yarn"
 
   def install
-    File.write("#{ENV["HOME"]}/.bashrc", "")
-    mkdir_p "#{ENV["HOME"]}/.config/fish"
-    File.write("#{ENV["HOME"]}/.config/fish/config.fish", "")
+    File.write("#{ENV['HOME']}/.bashrc", "")
+    mkdir_p "#{ENV['HOME']}/.config/fish"
+    File.write("#{ENV['HOME']}/.config/fish/config.fish", "")
     system "node", "yvm.js", "configure-shell", "--yvmDir", "."
     update_self_disabled = "echo 'YVM update-self disabled. Use `brew upgrade yvm`.'"
     inreplace "yvm.sh" do |s|
@@ -29,7 +29,7 @@ class Yvm < Formula
       s.gsub! "env YVM_INSTALL_DIR=$YVM_DIR curl -fsSL https://raw.githubusercontent.com/tophat/yvm"\
               "/master/scripts/install.js | node", update_self_disabled
     end
-    yarn_versions_dir = "#{ENV["HOME"]}/.yvm/versions"
+    yarn_versions_dir = "#{ENV['HOME']}/.yvm/versions"
     mkdir_p yarn_versions_dir
     ln_sf yarn_versions_dir, "./versions"
     File.write(".version", "{ \"version\": \"#{version}\" }")
@@ -37,14 +37,14 @@ class Yvm < Formula
   end
 
   def caveats
-    <<~EOS
+    <<~POSTINSTALLCONFIG
       Run the following command to configure your shell rc file
       $ node "#{prefix}/yvm.js" configure-shell --yvmDir "#{prefix}"
-    EOS
+    POSTINSTALLCONFIG
   end
 
   test do
-    File.write("#{ENV["HOME"]}/.bashrc", "")
+    File.write("#{ENV['HOME']}/.bashrc", "")
     system "node", "#{prefix}/yvm.js", "configure-shell", "--yvmDir", prefix.to_s
     assert_match prefix.to_s, shell_output("bash -i -c 'echo $YVM_DIR'").strip
     shell_output("bash -i -c 'yvm ls-remote'")


### PR DESCRIPTION
Fixes #46

Brew does not allow modifying of non sandbox files during installation. This create the config files in the installation directory for referencing in the post install instructions.

* `brew install Formula/yvm.rb`
* `brew test Formula/yvm.rb`